### PR TITLE
Add patches and dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile1
+ARG VERSION=20.04
+FROM ubuntu:$VERSION
+ENV USERNAME dev
+# Insert your generated `pymatgen` API key below in place of
+# `insert-api-key-here` before building
+ENV MP_API_KEY insert-api-key-here
+WORKDIR /home/$USERNAME
+
+COPY . ./piro/
+
+RUN apt-get update \
+ && apt-get -y update \
+ && apt-get install -y \
+    build-essential \
+    git \
+    python3 \
+    python3-dev \
+    python3-setuptools \
+    python3-pip \
+ && apt-get clean -qq
+
+RUN pip3 install -U numpy Cython jupyter
+
+RUN git clone https://github.com/hackingmaterials/matminer.git
+
+WORKDIR /home/$USERNAME/matminer/
+
+# A pinned version of `matminer` with most recent `pymatgen` import patches
+RUN git checkout dd6a7326dca0f28527c76a0a5a6b9198999fb558
+
+RUN python3 setup.py install
+
+WORKDIR /home/$USERNAME/piro/
+
+RUN python3 setup.py develop

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## *piro:* rational planning of solid-state synthesis routes for inorganics
+# *piro:* rational planning of solid-state synthesis routes for inorganics
 
 _piro_ is a recommendation system for navigation and planning of synthesis of 
 inorganic materials based on classical nucleation theory 
@@ -11,3 +11,36 @@ works with Materials Project data via its Rester API.
 (i.e. laying out the reaction pathways necessary to arrive at the target from practical/purchasable reagents/starting materials)
 
 - _piro_ supports generation of interactive plots and a web-UI for easy-navigation.
+
+## Prerequisites
+
+### Generate a pymatgen API key
+ - `piro` has a dependency on `pymatgen` which requires you to generate an API key.  Go [here](https://materialsproject.org/open) and follow the instructions to generate your API key.
+
+### Install Docker (optional)
+ - If you wish to build and use `piro` locally within a Docker container, you will need to install Docker first if you haven't already, go [here](https://docs.docker.com/get-docker/) and follow the instructions in order to install Docker.
+
+## Building Locally
+
+###  Docker
+
+Using the `Dockerfile` will likely be the quickest way to get `piro` up and running with little configuration necessary on your end.
+
+ 1. Before building your Docker container, you will need to open the `Dockerfile` file and replace `insert-api-key-here` with your own generated `pymatgen` API key (see [here](#generate-a-pymatgen-api-key)).
+
+ 1. Once you have substituted your own `pymatgen` API key, you can build your Docker container by running the following command from within your cloned `piro` repository:
+     ```
+     docker build -t piro:v1 .
+     ```
+
+ 1. Once this command is finished executing, run:
+     ```
+     docker run -p 8888:8888 -it piro:v1 /bin/bash
+     ```
+
+ 1. You can now develop with `piro` in this container, try out a Jupyter notebook by running:
+     ```
+     jupyter notebook --ip 0.0.0.0 --no-browser --allow-root
+     ```
+
+    - Go to the link output by the `jupyter` command in your local browser.  Once you navigate to an example `jupyter` notebook in `piro/notebooks/`, you can select one to then execute in the web browser.

--- a/piro/route.py
+++ b/piro/route.py
@@ -6,7 +6,7 @@ import pandas as pd
 import os
 import json
 from copy import deepcopy
-from pymatgen import MPRester
+from pymatgen.ext.matproj import MPRester
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.util.string import latexify
 from piro.data import GASES, GAS_RELEASE, DEFAULT_GAS_PRESSURES

--- a/piro/utils.py
+++ b/piro/utils.py
@@ -4,7 +4,7 @@ import pickle
 import numpy as np
 import json
 from copy import deepcopy
-from pymatgen import Composition
+from pymatgen.core.composition import Composition
 from pymatgen.analysis.substrate_analyzer import SubstrateAnalyzer
 from matminer.featurizers.base import MultipleFeaturizer
 from matminer.featurizers.composition import (
@@ -45,9 +45,9 @@ def through_cache(_parents, target, type="epitaxy"):
     indices_compt = [i for i in range(len(ordered_pairs)) if ordered_pairs[i] not in db]
 
     if type == "epitaxy" and indices_compt:
-        _res = epitaxy(np.array(_parents)[indices_compt].tolist(), target)
+        _res = epitaxy(np.array(_parents, dtype="object")[indices_compt].tolist(), target)
     elif type == "similarity" and indices_compt:
-        _res = similarity(np.array(_parents)[indices_compt].tolist(), target)
+        _res = similarity(np.array(_parents, dtype="object")[indices_compt].tolist(), target)
     else:
         _res = []
     results = []

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,9 @@ setup(
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    install_requires=["matminer==0.6.4",
-                      "scikit-learn==0.23.2",
-                      "plotly==4.13.0",
+    install_requires=["matminer==0.6.5",
+                      "scikit-learn==0.24.2",
+                      "plotly==4.14.3",
                       "pymatgen"
                       ],
     classifiers=[

--- a/web/layout.py
+++ b/web/layout.py
@@ -8,7 +8,8 @@ import dash_html_components as html
 from dash.dependencies import Input, Output, State
 from piro.route import SynthesisRoutes
 from dash.exceptions import PreventUpdate
-from pymatgen import Composition, MPRester
+from pymatgen.ext.matproj import MPRester
+from pymatgen.core.composition import Composition
 from fnmatch import fnmatch
 
 


### PR DESCRIPTION
Some versioning bumps and patches due to some breaking changes made in `pymatgen` (https://pymatgen.org/compatibility.html) as well as a Dockerfile that will now create the container space with piro built within it along with some documentation.

I felt like this is a good first step to getting some a more consistent build established as well as a good starting place for research labs wishing to run computations locally but not having much knowledge of building code and/or environment configuration.

This is intended to be a first iteration, as in, this was the bare minimum I had to personally do to get `piro` working in a Docker container - I'm sure more refining and changes will need to be made when considering the future of maintainability and usability.

I updated the `README` to contain instructions on how to build the docker container.