### PR TITLE
Add docker dash support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,16 @@ RUN apt-get update \
 
 RUN python3.7 -m pip install --upgrade \
     setuptools \
-    numpy
+    numpy \
+    wheel
+
+RUN python3.7 -m pip install --upgrade \
+    dash \
+    jupyter
 
 WORKDIR /home/$USERNAME/piro/
+
+# Set ip and 
+RUN find . -name 'app.py' | xargs sed -i "s/app.run_server(debug=True)/app.run_server(host='0.0.0.0', port=8888, debug=True)/g"
 
 RUN python3.7 setup.py develop

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION=18.04
 FROM ubuntu:$VERSION
 ARG PYMATGEN_API_KEY
 ENV USERNAME dev
-ENV MP_API_KEY $PYMATGEN_API_KEY
+ENV MP_API_KEY=$PYMATGEN_API_KEY
 WORKDIR /home/$USERNAME
 
 COPY . ./piro/
@@ -35,8 +35,5 @@ RUN python3.7 -m pip install --upgrade \
     jupyter
 
 WORKDIR /home/$USERNAME/piro/
-
-# Set ip and port of Dash app for Docker
-RUN find . -name 'app.py' | xargs sed -i "s/app.run_server(debug=True)/app.run_server(host='0.0.0.0', port=8080, debug=True)/g"
 
 RUN python3.7 setup.py develop

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile1
+# syntax=docker/dockerfile:1
 ARG VERSION=18.04
 FROM ubuntu:$VERSION
 ARG PYMATGEN_API_KEY
@@ -36,7 +36,7 @@ RUN python3.7 -m pip install --upgrade \
 
 WORKDIR /home/$USERNAME/piro/
 
-# Set ip and 
-RUN find . -name 'app.py' | xargs sed -i "s/app.run_server(debug=True)/app.run_server(host='0.0.0.0', port=8888, debug=True)/g"
+# Set ip and port of Dash app for Docker
+RUN find . -name 'app.py' | xargs sed -i "s/app.run_server(debug=True)/app.run_server(host='0.0.0.0', port=8080, debug=True)/g"
 
 RUN python3.7 setup.py develop

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Using the `Dockerfile` will likely be the quickest way to get a local `piro` dev
 
  1. Once this command is finished executing, run:
      ```
-     docker run -p 8888:8888 -it piro:v1 /bin/bash
+     docker run -p 8888:8888 -p 8080:8080 -it piro:v1 /bin/bash
      ```
     You can now develop with `piro` in this container
 

--- a/README.md
+++ b/README.md
@@ -14,31 +14,81 @@ works with Materials Project data via its Rester API.
 
 ## Prerequisites
 
+### Python 3.7
+ - `piro` uses Python 3.7.  If you wish to develop or run a local server, we recommend following the Docker instructions below to create your own `piro` container instead of configuring your local environment.
+
 ### Generate a pymatgen API key
  - `piro` has a dependency on `pymatgen` which requires you to generate an API key.  Go [here](https://materialsproject.org/open) and follow the instructions to generate your API key.
 
-### Install Docker (optional)
- - If you wish to build and use `piro` locally within a Docker container, you will need to install Docker first if you haven't already, go [here](https://docs.docker.com/get-docker/) and follow the instructions in order to install Docker.
+### Docker (optional)
+ - If you wish to develop on and build `piro`, the easiest way to get started is Docker. If you haven't already, go [here](https://docs.docker.com/get-docker/) and follow the instructions in order to install the Docker Engine.
+ - Additionally, if you would simply like to host your own local server quickly, install Docker Compose [here](https://docs.docker.com/compose/install/). 
 
-## Building Locally
+## Setup
 
-###  Docker
+###  - `piro` Environment for Local Development
 
-Using the `Dockerfile` will likely be the quickest way to get `piro` up and running with little configuration necessary on your end.
+Using the `Dockerfile` will likely be the quickest way to get a local `piro` development environment up and running with little configuration necessary on your end.
 
  1. Build your Docker container by running the following command from within your cloned `piro` repository, being sure to substitute your own `pymatgen` API key in place of the below `{insert key here}` portion:
      ```
-     docker build -t piro:v1 --build-arg PYMATGEN_APY_KEY={insert key here} .
+     docker build -t piro:v1 --build-arg PYMATGEN_API_KEY={insert key here} .
      ```
 
  1. Once this command is finished executing, run:
      ```
      docker run -p 8888:8888 -it piro:v1 /bin/bash
      ```
+    You can now develop with `piro` in this container
 
- 1. You can now develop with `piro` in this container, try out a Jupyter notebook by running:
+### - `piro` Local Server Hosting
+ 1. Build the Docker container with Docker Compose, being sure to substitute your own `pymatgen` API key in place of the below `{insert key here}` portion:
+
+    ```
+    docker-compose build --build-arg PYMATGEN_API_KEY={insert key here}
+    ```
+ 1. Run the `piro` server:
+    ```
+    docker-compose up
+    ```
+    And then navigate to the link output by Dash in the command line.
+
+## Usage
+
+ - Rebuild the codebase:
+   - Natively:
+     ```
+     python setup.py develop
+     ```
+   - In Docker:
+     ```
+     python3.7 setup.py develop
+     ```
+ - Try out a Jupyter notebook:
+   - Natively:
+     ```
+     jupyter notebook
+     ```
+   - In Docker:
      ```
      jupyter notebook --ip 0.0.0.0 --no-browser --allow-root
      ```
+     And then go to the link output by the `jupyter` command in your local browser.  Once you navigate to an example `jupyter` notebook in `piro/notebooks/`, you can select one to then execute in the web browser.
+  - Run a local server:
+    - Natively:
+      ```
+      python web/app.py
+      ```
+    - In Docker:
+      ```
+      python3.7 web/app.py
+      ```
+      And then navigate to the link output by Dash in the command line.
 
-    - Go to the link output by the `jupyter` command in your local browser.  Once you navigate to an example `jupyter` notebook in `piro/notebooks/`, you can select one to then execute in the web browser.
+## Debugging
+  - If you receive an error like
+    ```
+    Creating network "piro_default" with the default driver
+    ERROR: could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network
+    ```
+    when attempting to run the Dash server, you will likely need to disable any VPNs you may have running.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ works with Materials Project data via its Rester API.
 ### Python 3.7
  - `piro` uses Python 3.7.  If you wish to develop or run a local server, we recommend following the Docker instructions below to create your own `piro` container instead of configuring your local environment.
 
-### Generate a pymatgen API key
+### Pymatgen API key
  - `piro` has a dependency on `pymatgen` which requires you to generate an API key.  Go [here](https://materialsproject.org/open) and follow the instructions to generate your API key.
 
 ### Docker (optional)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+
+  dash:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: piro_dash
+    command: python3.7 web/app.py
+    ports:
+      - "8888:8888"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,4 @@ services:
     container_name: piro_dash
     command: python3.7 web/app.py
     ports:
-      - "8888:8888"
+      - "8080:8080" # For Dash

--- a/web/app.py
+++ b/web/app.py
@@ -47,4 +47,4 @@ app.config.suppress_callback_exceptions = True  # TODO: remove this?
 #            }
 
 if __name__ == '__main__':
-    app.run_server(debug=True)
+    app.run_server(host='0.0.0.0', port=8080, debug=True)


### PR DESCRIPTION
 - Adds support for a two-liner for getting a local `piro` server up and running
 - Rework of the `README` - would like to hear thoughts on this, I tried to segment things out in an intuitive way but it still seems a bit patchy to me