### PR TITLE
Speedup other reaction calculations

### DIFF
--- a/piro/reactions.py
+++ b/piro/reactions.py
@@ -1,19 +1,17 @@
 import itertools
 import logging
-from copy import deepcopy
-
 import scipy
 from numpy import ndarray
+from pymatgen.core import Composition
 from scipy.special import comb
-from typing import List, Dict, Tuple, Any
+from typing import List, Dict, Tuple, Any, Union
 
 import numpy as np
 from pymatgen.entries.computed_entries import ComputedStructureEntry
 from tqdm.autonotebook import tqdm
 
-from piro.data import GAS_RELEASE
-from piro.utils import get_fractional_composition, get_v, get_reduced_formula
-
+from piro.data import GAS_RELEASE, ST, H, GASES
+from piro.utils import get_v
 
 logger = logging.getLogger(__name__)
 
@@ -25,39 +23,35 @@ class Reaction:
 
     def __init__(
             self,
-            precursors: List[ComputedStructureEntry],
+            reduced_formulas: Tuple[str],
             target_entry: ComputedStructureEntry,
-            elements: List[str],
-            allow_gas_release: bool = False
+            elements: List[str]
     ):
-        self.precursors = precursors
-        self.reduced_formulas = tuple([get_reduced_formula(p) for p in self.precursors])
-
-        if len(set(self.reduced_formulas)) != len(self.reduced_formulas):
-            raise self.SkipReaction('Reaction has duplicate formula')
+        self.reduced_formulas = reduced_formulas
 
         self.elements = elements
-        self.allow_gas_release = allow_gas_release
         self.target_entry = target_entry
 
         self.coeffs = None
-        self.removed_coeff_indexes = None
+        self.removed_coeff_indexes = []
         self.main_formulas = None
 
-    def get_balanced_reaction(self) -> Tuple[Any, List[int], ndarray]:
-        target_c = get_v(
-            get_fractional_composition(self.target_entry), self.elements
-        )
+    def get_balanced_reaction(
+            self,
+            precursors: List[ComputedStructureEntry],
+            allow_gas_release: bool = False
+    ) -> Tuple[Any, List[int], ndarray]:
+        if len(set(self.reduced_formulas)) != len(self.reduced_formulas):
+            raise self.SkipReaction('Reaction has duplicate formula')
 
-        c = [
-            get_v(e, self.elements)
-            for e in [get_fractional_composition(p) for p in self.precursors]
-        ]
-        if np.any(np.sum(np.array(c), axis=0) == 0.0):
+        target_c = self.target_entry.data['v']
+        c = np.vstack([p.data['v'] for p in precursors])
+
+        if np.any(np.sum(c, axis=0) == 0.0):
             raise self.SkipReaction('Reaction as sum 0 c')
 
         try:
-            coeffs = np.linalg.solve(np.vstack(c).T, target_c)
+            coeffs = np.linalg.solve(c.T, target_c)
         except:
             # need better handling here.
             raise self.SkipReaction('Reaction could not solve for coeffs')
@@ -66,7 +60,7 @@ class Reaction:
             raise self.SkipReaction('Reaction has a coeff over 100')
 
         if np.any(coeffs < 0.0):
-            if not self.allow_gas_release:
+            if not allow_gas_release:
                 raise self.SkipReaction('Reaction has a gas release')
             else:
                 if not set(np.array(self.reduced_formulas)[coeffs < 0.0]).issubset(GAS_RELEASE):
@@ -75,11 +69,11 @@ class Reaction:
         removed_coeff_indexes = []
         for i in reversed(range(len(coeffs))):
             if np.abs(coeffs[i]) < 0.00001:
-                c.pop(i)
+                c = np.delete(c, i, 0)
                 coeffs = np.delete(coeffs, i)
                 removed_coeff_indexes.append(i)
 
-        effective_rank = scipy.linalg.lstsq(np.vstack(c).T, target_c)[2]
+        effective_rank = scipy.linalg.lstsq(c.T, target_c)[2]
         if effective_rank < len(coeffs):
             # Removes under-determined reactions.
             # print(effective_rank, precursor_formulas, \
@@ -89,7 +83,312 @@ class Reaction:
         main_formulas = np.array([
             p for i, p in enumerate(self.reduced_formulas) if i not in removed_coeff_indexes
         ])
-        return coeffs, removed_coeff_indexes, main_formulas
+
+        self.coeffs = coeffs
+        self.removed_coeff_indexes = removed_coeff_indexes
+        self.main_formulas = main_formulas
+        return self.coeffs, self.removed_coeff_indexes, self.main_formulas
+
+    def filter_entries(self, entries: List[ComputedStructureEntry]) -> List[ComputedStructureEntry]:
+        return [e for i, e in enumerate(entries) if i not in self.removed_coeff_indexes]
+
+
+class ReactionResult:
+
+    def __init__(
+        self,
+        sorted_precursors: List[ComputedStructureEntry],
+        reaction: Reaction
+    ):
+        self.sorted_precursors = sorted_precursors
+        self.reaction = reaction
+
+        self.precursors = self.reaction.filter_entries(sorted_precursors)
+        self.entry_ids = [str(p.entry_id) for p in self.precursors]
+        self.label = "_".join(sorted(self.entry_ids))
+
+        self.energy = None
+        self.enthalpy = None
+        self.temperature = None
+
+        self.barrier = None
+        self._params = None
+
+        self.summary = None
+
+        self.competing = None
+        self.competing_rxe = None
+        self.n_competing = None
+
+    def as_dict(self) -> dict:
+        return {
+            "precursors": self.precursors,
+            "coeffs": self.reaction.coeffs,
+            "precursor_formulas": self.reaction.main_formulas,
+            "precursor_ids": self.entry_ids,
+            "energy": self.energy,
+            "enthalpy": self.enthalpy,
+            "temperature": self.temperature,
+            "barrier": self.barrier,
+            "_params": self._params,
+            "summary": self.summary,
+            "competing": self.competing,
+            "competing_rxe": self.competing_rxe,
+            "n_competing": self.n_competing
+        }
+
+    def update_reaction_summary(self):
+        coeffs = self.reaction.coeffs
+        num_sites = self.reaction.target_entry.data['reduced_composition_sum']
+        _coeffs = []
+        for i in range(len(coeffs)):
+            p = self.precursors[i]
+            _coeffs.append(
+                coeffs[i]
+                / p.data['reduced_composition_sum']
+                * num_sites
+            )
+        _coeffs = np.round(_coeffs, decimals=4)
+        report = " + ".join(
+            [f'{str(c)} {p.data["reduced_formula"]}({str(p.entry_id)})' for c, p in zip(_coeffs, self.precursors)]
+        )
+        self.summary = report
+        return self.summary
+
+    @staticmethod
+    def get_energies_and_enthalpies(
+            entries: List[ComputedStructureEntry],
+            temperature: float,
+            pressure: Union[float, dict] = 1
+    ) -> Tuple[List[float], List[float]]:
+        """
+        Modify entry objects corresponding to gas phases to account for enthalpy and entropy
+        changes wrt. T and standard pressure.
+        """
+        formation_energy_per_atom_list = []
+        enthalpy_list = []
+        for e in entries:
+            c = e.data['reduced_formula']
+            if c in ST:
+                if isinstance(pressure, dict):
+                    pp = pressure.get(c, 1.0)
+                else:
+                    pp = pressure
+                formation_energy_per_atom_list.append(
+                    H.get(c, 0.0)
+                    - ST[c][temperature]
+                    + 8.6173324e-5 * temperature * np.log(pp) / Composition(c).num_atoms
+                )
+                enthalpy_list.append(H.get(c, 0.0))
+            else:
+                formation_energy_per_atom_list.append(e.data['formation_energy_per_atom'])
+                enthalpy_list.append(
+                    e.data['enthalpy'] if 'enthalpy' in e.data else e.data['formation_energy_per_atom']
+                )
+
+        return formation_energy_per_atom_list, enthalpy_list
+
+    def update_reaction_energy(
+            self,
+            temperature: float = 298,
+            pressure: Union[float, dict] = 1
+    ) -> float:
+        target_entry_energy = self.reaction.target_entry.data["formation_energy_per_atom"]
+        energies, enthalpies = self.get_energies_and_enthalpies(
+            self.precursors,
+            temperature,
+            pressure
+        )
+        self.energy = target_entry_energy - np.sum(self.reaction.coeffs * np.array(energies))
+        self.enthalpy = target_entry_energy - np.sum(self.reaction.coeffs * np.array(enthalpies))
+        self.temperature = temperature
+
+        return self.energy
+
+    @staticmethod
+    def f(q):
+        S = 1.0 - 2 * q
+        if S < -1:
+            S = -1
+        elif S > 1:
+            S = 1
+        return (2 - 3 * S + S ** 3) / 4
+
+    def update_nucleation_barrier(
+            self,
+            epitaxies: dict,
+            similarities: dict,
+            sigma: float,
+            transport_constant: float
+    ) -> float:
+        if self.energy > 0.0:
+            self.barrier = np.inf
+            self._params = None
+            return self.barrier
+
+        target_s = self.reaction.target_entry.structure
+        delta_Gv = self.energy * target_s.num_sites / target_s.volume
+
+        q_epi = (
+            min(
+                [
+                    epitaxies[i.entry_id]
+                    for i in self.precursors
+                    if i.data['reduced_formula'] not in GASES
+                ]
+            )
+            / 1000.0
+        )
+        q_epi = min(q_epi, 1.0)
+
+        try:
+            q_sim = min(
+                [
+                    similarities[i.entry_id]
+                    for i in self.precursors
+                    if int(similarities[i.entry_id]) != -1
+                    and i.data['reduced_formula'] not in GASES
+                ]
+            )
+        except:
+            # better handling needed
+            q_sim = 1.0
+
+        f_t = self.f((q_epi + q_sim) / 2.0)
+        G_star = 16 / 3 * np.pi * sigma ** 3 * f_t / delta_Gv ** 2
+        E_d = transport_constant * q_sim
+
+        self.barrier = G_star + E_d
+        self._params = {
+            "f_t": f_t,
+            "G_star": G_star,
+            "E_d": E_d,
+            "q_sim": q_sim,
+            "q_epi": q_epi,
+        }
+
+        return self.barrier
+
+    def update_competing_phases(
+            self,
+            entries: List[ComputedStructureEntry],
+            confine_to_icsd: bool = True,
+            flexible_competition: int = 0,
+            allow_gas_release: bool = False,
+            temperature: float = 298,
+            pressure: Union[float, dict] = 1
+
+    ):
+
+        precursor_ids = [i.entry_id for i in self.precursors]
+        _competing = []
+        _competing_rxe = []
+
+        target_entry_keys = self.reaction.target_entry.data['composition_keys']
+
+        elts_precs = set()
+        for p in self.precursors:
+            for k in p.data['composition_keys']:
+                elts_precs.add(k)
+        sorted_elts_precs = sorted(str(s) for s in elts_precs)
+        c = [
+            get_v(e.composition.fractional_composition, tuple(sorted_elts_precs))
+            for e in self.precursors
+        ]
+
+        precursor_formulas = np.array(
+            self.reaction.main_formulas
+        )
+
+        for entry in entries:
+            if confine_to_icsd:
+                if not entry.data["icsd_ids"]:
+                    continue
+
+            if 'composition_keys' not in entry.data:
+                entry.data['composition_keys'] = set(entry.composition.as_dict().keys())
+
+            entry_keys = entry.data['composition_keys']
+            if flexible_competition:
+                if not (
+                    entry_keys.issubset(target_entry_keys)
+                    and
+                    (len(target_entry_keys) - flexible_competition <= len(entry_keys) <= len(target_entry_keys))
+                ):
+                    continue
+            else:
+                if not target_entry_keys.issubset(entry_keys):
+                    continue
+            if entry.entry_id in precursor_ids:
+                continue
+            if entry.entry_id == self.reaction.target_entry.entry_id:
+                continue
+            competing_target_entry = entry
+
+            if not entry_keys.issubset(elts_precs):
+                # print(entry.composition)
+                continue
+
+            target_c = get_v(
+                competing_target_entry.composition.fractional_composition,
+                tuple(sorted_elts_precs),
+            )
+
+            # trying to solve for compound fractions.
+            try:
+                coeffs = np.linalg.solve(np.vstack(c).T, target_c)
+            except:
+                try:
+                    x = scipy.sparse.linalg.lsqr(np.vstack(c).T, target_c)
+                    coeffs = x[0]
+                    if x[1] != 1:
+                        continue
+                except:
+                    print(
+                        "     failed:",
+                        competing_target_entry.composition.reduced_formula,
+                        precursor_formulas,
+                    )
+                    print(np.vstack(c).T, target_c)
+                    continue
+            if np.any(coeffs < 0.0):
+                if not allow_gas_release:
+                    continue
+                else:
+                    if not set(precursor_formulas[coeffs < 0.0]).issubset(GAS_RELEASE):
+                        continue
+
+            indexes_to_remove = []
+            for i in sorted(range(len(coeffs)), reverse=True):
+                if np.abs(coeffs[i]) < 0.00001:
+                    indexes_to_remove.append(i)
+                    coeffs = np.delete(coeffs, i)
+
+            try:
+                effective_rank = scipy.linalg.lstsq(np.vstack(c).T, target_c)[2]
+                if effective_rank < len(coeffs):
+                    # print(precursor_formulas, coeffs)
+                    # Removes under-determined reactions.
+                    continue
+            except:
+                continue
+
+            energies, _ = self.get_energies_and_enthalpies(
+                [p for i, p in enumerate(self.precursors) if i not in indexes_to_remove],
+                temperature,
+                pressure
+            )
+
+            rx_e = competing_target_entry.data["formation_energy_per_atom"] - np.sum(
+                coeffs * energies
+            )
+            if rx_e < 0.0:
+                _competing.append(competing_target_entry.entry_id)
+                _competing_rxe.append((rx_e))
+        self.competing = _competing
+        self.competing_rxe = _competing_rxe
+        self.n_competing = len(_competing)
+        return self.n_competing
 
 
 class Reactions:
@@ -99,43 +398,94 @@ class Reactions:
             target_entry: ComputedStructureEntry,
             elements: List[str],
             precursor_library: List[ComputedStructureEntry],
-            allow_gas_release: bool = False
+            epitaxies: dict,
+            similarities: dict,
+            entries: List[ComputedStructureEntry],
+            allow_gas_release: bool = False,
+            temperature: float = 298,
+            pressure: Union[float, dict] = 1,
+            sigma: float = 2 * 6.242 * 0.01,
+            transport_constant: float = 10.0,
+            confine_competing_to_icsd: bool = True,
+            flexible_competition: int = 0
     ):
         self.target_entry = target_entry
         self.elements = elements
         self.precursor_library = precursor_library
         self.allow_gas_release = allow_gas_release
 
+        self.temperature = temperature
+        self.pressure = pressure
+
+        self.epitaxies = epitaxies
+        self.similarities = similarities
+        self.sigma = sigma
+        self.transport_constant = transport_constant
+
+        self.entries = entries
+        self.confine_competing_to_icsd = confine_competing_to_icsd
+        self.flexible_competition = flexible_competition
+
     def get_reactions(self) -> Dict:
         reactions_dict = {}
 
-        results_by_reduced_formulas = dict()
+        reaction_by_reduced_formulas = dict()
+
+        # cache things
+        self.target_entry.data['v'] = get_v(
+            self.target_entry.composition.fractional_composition, tuple(self.elements)
+        )
+        self.target_entry.data['composition_keys'] = set(self.target_entry.composition.as_dict().keys())
+        self.target_entry.data['reduced_composition_sum'] = sum(
+            self.target_entry.composition.reduced_composition.as_dict().values()
+        )
+
+        for p in self.precursor_library:
+            p.data['v'] = get_v(
+                p.composition.fractional_composition, tuple(self.elements)
+            )
+            p.data['reduced_formula'] = p.composition.reduced_formula
+            p.data['composition_keys'] = set(p.composition.as_dict().keys())
+            p.data['reduced_composition_sum'] = sum(p.composition.reduced_composition.as_dict().values())
 
         for precursors in tqdm(
                 itertools.combinations(self.precursor_library, len(self.elements)),
                 total=comb(len(self.precursor_library), len(self.elements)),
         ):
             try:
-                sorted_precursors = sorted(precursors, key=get_reduced_formula)
-                reaction = Reaction(sorted_precursors, self.target_entry, self.elements, self.allow_gas_release)
+                sorted_precursors = sorted(precursors, key=lambda p: p.data['reduced_formula'])
+                reduced_formulas = tuple([str(p.data['reduced_formula']) for p in sorted_precursors])
+                if reduced_formulas not in reaction_by_reduced_formulas:
+                    reaction = Reaction(reduced_formulas, self.target_entry, self.elements)
+                    reaction.get_balanced_reaction(sorted_precursors, self.allow_gas_release)
+                    reaction_by_reduced_formulas[reduced_formulas] = reaction
 
-                if reaction.reduced_formulas not in results_by_reduced_formulas:
-                    results_by_reduced_formulas[reaction.reduced_formulas] = reaction.get_balanced_reaction()
+                reaction = reaction_by_reduced_formulas[reduced_formulas]
+                reaction_result = ReactionResult(sorted_precursors, reaction)
 
-                coeffs, removed_coeff_indexes, main_formulas = results_by_reduced_formulas[reaction.reduced_formulas]
-
-                main_precursors = [p for i, p in enumerate(sorted_precursors) if i not in removed_coeff_indexes]
-                entry_ids = [str(e.entry_id) for e in main_precursors]
-                label = "_".join(sorted(entry_ids))
-                if label in reactions_dict:
+                if reaction_result.label in reactions_dict:
                     continue
                 else:
-                    reactions_dict[label] = {
-                        "precursors": deepcopy(main_precursors),
-                        "coeffs": coeffs,
-                        "precursor_formulas": main_formulas,
-                        "precursor_ids": entry_ids,
-                    }
+                    reaction_result.update_reaction_energy(
+                        self.temperature,
+                        self.pressure
+                    )
+                    reaction_result.update_nucleation_barrier(
+                        self.epitaxies,
+                        self.similarities,
+                        self.sigma,
+                        self.transport_constant
+                    )
+                    reaction_result.update_reaction_summary()
+                    reaction_result.update_competing_phases(
+                        self.entries,
+                        self.confine_competing_to_icsd,
+                        self.flexible_competition,
+                        self.allow_gas_release,
+                        self.temperature,
+                        self.pressure
+                    )
+                    reactions_dict[reaction_result.label] = reaction_result.as_dict()
 
             except Reaction.SkipReaction as e:
                 logger.debug("Skipping precursors %s: %s", precursors, e)

--- a/piro/route.py
+++ b/piro/route.py
@@ -4,13 +4,12 @@ import pandas as pd
 import os
 import json
 
-import scipy
 from pymatgen.ext.matproj import MPRester
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.util.string import latexify
 from piro.data import GASES, GAS_RELEASE, DEFAULT_GAS_PRESSURES
 from piro.reactions import Reactions
-from piro.utils import epitaxy, similarity, through_cache, get_v, update_gases
+from piro.utils import epitaxy, similarity, through_cache
 from piro.mongodb import query_epitaxies, query_similarities
 from piro import RXN_FILES
 

--- a/piro/route.py
+++ b/piro/route.py
@@ -254,13 +254,14 @@ class SynthesisRoutes:
 
     def get_reactions(self):
 
+        reactions = {}
         for reaction_result in generate_reactions(
                 self.target_entry,
                 self.elts,
                 self.precursor_library,
                 self.allow_gas_release
         ):
-            if reaction_result.label in self.reactions:
+            if reaction_result.label in reactions:
                 continue
             else:
                 reaction_result.update_reaction_energy(
@@ -282,10 +283,10 @@ class SynthesisRoutes:
                     self.temperature,
                     self.pressure
                 )
-                self.reactions[reaction_result.label] = reaction_result.as_dict()
+                reactions[reaction_result.label] = reaction_result.as_dict()
 
-        logger.info(f"Total # of balanced reactions obtained: {len(self.reactions)}")
-        return self.reactions
+        logger.info(f"Total # of balanced reactions obtained: {len(reactions)}")
+        return reactions
 
     def recommend_routes(
         self,
@@ -318,7 +319,7 @@ class SynthesisRoutes:
             self.pressure = pressure if pressure else self.pressure
             self.allow_gas_release = allow_gas_release
             self.confine_competing_to_icsd = confine_competing_to_icsd
-            self.get_reactions()
+            self.reactions = self.get_reactions()
             self.check_if_known_precursors()
 
         self.plot_data = pd.DataFrame.from_dict(self.reactions, orient="index")[

--- a/piro/route.py
+++ b/piro/route.py
@@ -1,15 +1,16 @@
-import scipy
 import numpy as np
 import plotly.express as px
 import pandas as pd
 import os
 import json
+
+import scipy
 from pymatgen.ext.matproj import MPRester
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.util.string import latexify
 from piro.data import GASES, GAS_RELEASE, DEFAULT_GAS_PRESSURES
 from piro.reactions import Reactions
-from piro.utils import get_v, epitaxy, similarity, update_gases, through_cache
+from piro.utils import epitaxy, similarity, through_cache, get_v, update_gases
 from piro.mongodb import query_epitaxies, query_similarities
 from piro import RXN_FILES
 
@@ -245,256 +246,18 @@ class SynthesisRoutes:
             self.target_entry,
             self.elts,
             self.precursor_library,
-            self.allow_gas_release
+            self.epitaxies,
+            self.similarities,
+            self.entries,
+            self.allow_gas_release,
+            self.temperature,
+            self.pressure,
+            self._sigma,
+            self._transport_constant,
+            self.confine_competing_to_icsd,
+            self.flexible_competition
         ).get_reactions()
         return self.reactions
-
-    def get_reaction_energy(self, rxn_label, verbose=False):
-        precursors = update_gases(
-            self.reactions[rxn_label]["precursors"],
-            T=self.temperature,
-            P=self.pressure,
-            copy=True,
-        )
-        # Free energy per atom
-        energies = np.array([e.data["formation_energy_per_atom"] for e in precursors])
-        self.reactions[rxn_label]["energy"] = self.target_entry.data[
-            "formation_energy_per_atom"
-        ] - np.sum(self.reactions[rxn_label]["coeffs"] * energies)
-        # Enthalpy energy per atom
-        enthalpies = np.array(
-            [
-                e.data["enthalpy"]
-                if "enthalpy" in e.data
-                else e.data["formation_energy_per_atom"]
-                for e in precursors
-            ]
-        )
-        self.reactions[rxn_label]["enthalpy"] = self.target_entry.data[
-            "formation_energy_per_atom"
-        ] - np.sum(self.reactions[rxn_label]["coeffs"] * enthalpies)
-
-        self.reactions[rxn_label]["temperature"] = self.temperature
-
-        if verbose:
-            print("target e: ", self.target_entry.data["formation_energy_per_atom"])
-            print("precursr: ", [e.composition.reduced_formula for e in precursors])
-            print("energies: ", energies)
-            print("coeffs:   ", self.reactions[rxn_label]["coeffs"])
-
-        return self.reactions[rxn_label]["energy"]
-
-    @staticmethod
-    def f(q):
-        S = 1.0 - 2 * q
-        if S < -1:
-            S = -1
-        elif S > 1:
-            S = 1
-        return (2 - 3 * S + S ** 3) / 4
-
-    @property
-    def sigma(self):
-        return self._sigma
-
-    @property
-    def transport_constant(self):
-        return self._transport_constant
-
-    def get_nucleation_barrier(self, rxn_label):
-        rx_e = self.reactions[rxn_label]["energy"]
-        if rx_e > 0.0:
-            self.reactions[rxn_label]["barrier"] = np.inf
-            self.reactions[rxn_label]["_params"] = None
-            return self.reactions[rxn_label]["barrier"]
-
-        target_s = self.target_entry.structure
-        delta_Gv = rx_e * target_s.num_sites / target_s.volume
-
-        precursors = self.reactions[rxn_label]["precursors"]
-        # precursor_formulas = self.reactions[rxn_label]["precursor_formulas"]
-
-        q_epi = (
-            min(
-                [
-                    self.epitaxies[i.entry_id]
-                    for i in precursors
-                    if i.structure.composition.reduced_formula not in GASES
-                ]
-            )
-            / 1000.0
-        )
-        q_epi = min(q_epi, 1.0)
-
-        try:
-            q_sim = min(
-                [
-                    self.similarities[i.entry_id]
-                    for i in precursors
-                    if int(self.similarities[i.entry_id]) != -1
-                    and i.structure.composition.reduced_formula not in GASES
-                ]
-            )
-        except:
-            # better handling needed
-            q_sim = 1.0
-
-        f_t = self.f((q_epi + q_sim) / 2.0)
-        G_star = 16 / 3 * np.pi * self.sigma ** 3 * f_t / delta_Gv ** 2
-        E_d = self.transport_constant * q_sim
-
-        self.reactions[rxn_label]["barrier"] = G_star + E_d
-        self.reactions[rxn_label]["_params"] = {
-            "f_t": f_t,
-            "G_star": G_star,
-            "E_d": E_d,
-            "q_sim": q_sim,
-            "q_epi": q_epi,
-        }
-
-        return self.reactions[rxn_label]["barrier"]
-
-    def get_rxn_summary(self, rxn_label):
-        coeffs = self.reactions[rxn_label]["coeffs"]
-        num_sites = sum(
-            self.target_entry.structure.composition.reduced_composition.as_dict().values()
-        )
-        _coeffs = []
-        for i in range(len(coeffs)):
-            p = self.reactions[rxn_label]["precursors"][i]
-            _coeffs.append(
-                coeffs[i]
-                / sum(p.structure.composition.reduced_composition.as_dict().values())
-                * num_sites
-            )
-        _coeffs = np.round(_coeffs, decimals=4)
-        report = " + ".join(
-            [
-                i + " " + j
-                for i, j in list(
-                    zip(
-                        [str(c) for c in _coeffs],
-                        [
-                            p.structure.composition.reduced_formula
-                            + "("
-                            + p.entry_id
-                            + ")"
-                            for p in self.reactions[rxn_label]["precursors"]
-                        ],
-                    )
-                )
-            ]
-        )
-        self.reactions[rxn_label]["summary"] = report
-        return report
-
-    def get_competing_phases(self, rxn_label, confine_to_icsd=True):
-
-        precursors = self.reactions[rxn_label]["precursors"]
-        precursor_ids = [i.entry_id for i in precursors]
-        _competing = []
-        _competing_rxe = []
-
-        for entry in self.entries:
-            if confine_to_icsd:
-                if not entry.data["icsd_ids"]:
-                    continue
-            if self.flexible_competition:
-                s1 = set(entry.composition.as_dict().keys())
-                s2 = set(self.target_entry.structure.composition.as_dict().keys())
-                if not (
-                    s1.issubset(s2)
-                    and (len(s2) - self.flexible_competition <= len(s1) <= len(s2))
-                ):
-                    continue
-            else:
-                if not set(self.target_entry.composition.as_dict().keys()).issubset(
-                    set(entry.structure.composition.as_dict().keys())
-                ):
-                    continue
-            if entry.entry_id in precursor_ids:
-                continue
-            if entry.entry_id == self.target_entry_id:
-                continue
-            competing_target_entry = entry
-
-            elts_precs = set()
-            for s in [
-                set(p.structure.composition.as_dict().keys()) for p in precursors
-            ]:
-                elts_precs = elts_precs.union(s)
-            if not set(entry.composition.as_dict().keys()).issubset(elts_precs):
-                # print(entry.composition)
-                continue
-
-            elts_precs = sorted(list(elts_precs))
-
-            target_c = get_v(
-                competing_target_entry.structure.composition.fractional_composition,
-                elts_precs,
-            )
-            c = [
-                get_v(e.structure.composition.fractional_composition, elts_precs)
-                for e in precursors
-            ]
-
-            precursor_formulas = np.array(
-                [p.structure.composition.reduced_formula for p in precursors]
-            )
-
-            # trying to solve for compound fractions.
-            try:
-                coeffs = np.linalg.solve(np.vstack(c).T, target_c)
-            except:
-                try:
-                    x = scipy.sparse.linalg.lsqr(np.vstack(c).T, target_c)
-                    coeffs = x[0]
-                    if x[1] != 1:
-                        continue
-                except:
-                    print(
-                        "     failed:",
-                        competing_target_entry.composition.reduced_formula,
-                        precursor_formulas,
-                    )
-                    print(np.vstack(c).T, target_c)
-                    continue
-            if np.any(coeffs < 0.0):
-                if not self.allow_gas_release:
-                    continue
-                else:
-                    if not set(precursor_formulas[coeffs < 0.0]).issubset(GAS_RELEASE):
-                        continue
-            _precursors = update_gases(
-                precursors, T=self.temperature, P=self.pressure, copy=True
-            )
-
-            for i in sorted(range(len(coeffs)), reverse=True):
-                if np.abs(coeffs[i]) < 0.00001:
-                    _precursors.pop(i)
-                    coeffs = np.delete(coeffs, i)
-
-            try:
-                effective_rank = scipy.linalg.lstsq(np.vstack(c).T, target_c)[2]
-                if effective_rank < len(coeffs):
-                    # print(precursor_formulas, coeffs)
-                    # Removes under-determined reactions.
-                    continue
-            except:
-                continue
-            energies = np.array(
-                [e.data["formation_energy_per_atom"] for e in _precursors]
-            )
-            rx_e = competing_target_entry.data["formation_energy_per_atom"] - np.sum(
-                coeffs * energies
-            )
-            if rx_e < 0.0:
-                _competing.append(competing_target_entry.entry_id)
-                _competing_rxe.append((rx_e))
-        self.reactions[rxn_label]["competing"] = _competing
-        self.reactions[rxn_label]["competing_rxe"] = _competing_rxe
-        self.reactions[rxn_label]["n_competing"] = len(_competing)
-        return len(_competing)
 
     def recommend_routes(
         self,
@@ -528,13 +291,8 @@ class SynthesisRoutes:
             self.allow_gas_release = allow_gas_release
             self.confine_competing_to_icsd = confine_competing_to_icsd
             self.get_reactions()
-            for rxn_label in self.reactions:
-                self.get_reaction_energy(rxn_label)
-                self.get_nucleation_barrier(rxn_label)
-                self.get_rxn_summary(rxn_label)
-                self.get_competing_phases(
-                    rxn_label, confine_to_icsd=confine_competing_to_icsd
-                )
+            # for label in self.reactions.keys():
+            #     self.get_competing_phases(label, self.confine_competing_to_icsd)
             self.check_if_known_precursors()
 
         self.plot_data = pd.DataFrame.from_dict(self.reactions, orient="index")[

--- a/piro/utils.py
+++ b/piro/utils.py
@@ -1,4 +1,3 @@
-from functools import lru_cache
 from typing import Tuple
 
 import pandas as pd
@@ -33,14 +32,8 @@ from piro.data import ST, H
 from piro import RXN_FILES
 
 
-@lru_cache()
-def get_composition_as_dict(composition: Composition) -> dict:
-    return composition.as_dict()
-
-
-@lru_cache()
 def get_v(c: Composition, elts: Tuple[str]) -> np.array:
-    c_dict = get_composition_as_dict(c)
+    c_dict = c.as_dict()
     return np.array([c_dict[el] for el in elts])
 
 

--- a/piro/utils.py
+++ b/piro/utils.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from typing import Tuple
 
 import pandas as pd
 import os
@@ -22,7 +23,6 @@ from matminer.featurizers.structure import (
     StructureComposition,
     MaximumPackingEfficiency,
 )
-from pymatgen.entries.computed_entries import ComputedStructureEntry
 from sklearn.preprocessing import StandardScaler
 from sklearn.metrics import pairwise_distances
 from sklearn.linear_model import LinearRegression
@@ -34,21 +34,12 @@ from piro import RXN_FILES
 
 
 @lru_cache()
-def get_reduced_formula(entry: ComputedStructureEntry) -> str:
-    return entry.composition.reduced_formula
-
-
-@lru_cache()
-def get_fractional_composition(entry: ComputedStructureEntry) -> Composition:
-    return entry.composition.fractional_composition
-
-
-@lru_cache()
 def get_composition_as_dict(composition: Composition) -> dict:
     return composition.as_dict()
 
 
-def get_v(c, elts):
+@lru_cache()
+def get_v(c: Composition, elts: Tuple[str]) -> np.array:
     c_dict = get_composition_as_dict(c)
     return np.array([c_dict[el] for el in elts])
 

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from unittest.mock import patch
 
 from numpy import nan, array
 from pandas._testing import assert_frame_equal
@@ -7,7 +6,6 @@ from pymatgen.entries.computed_entries import ComputedStructureEntry
 
 import pandas as pd
 
-from piro.reactions import Reaction
 from piro.route import SynthesisRoutes
 
 TARGET_ENTRY_DICT = {
@@ -1447,7 +1445,7 @@ SIMILARITIES = {
 
 EXPECTED_PLOT_DATA = [
     {'index': 'mp-1009657_mp-1018027_mp-2686',
-     'n_competing': 10,
+     'n_competing': 1,
      'barrier': 0.5789189802480729,
      'summary': '1.3333 Ca2N(mp-2686) + 0.3333 CaN2(mp-1009657) + 1.0 VN(mp-1018027)',
      'energy': -0.22549735714285668,
@@ -1455,7 +1453,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca2N', 'CaN2', 'VN'], dtype='<U4')},
     {'index': 'mp-1009657_mp-1018027_mp-45',
-     'n_competing': 12,
+     'n_competing': 1,
      'barrier': 0.19222015403712947,
      'summary': '2.0 Ca(mp-45) + 1.0 CaN2(mp-1009657) + 1.0 VN(mp-1018027)',
      'energy': -0.513877448571428,
@@ -1463,7 +1461,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca', 'CaN2', 'VN'], dtype='<U4')},
     {'index': 'mp-1009657_mp-1188283_mp-2686',
-     'n_competing': 11,
+     'n_competing': 1,
      'barrier': 0.20870340755772163,
      'summary': '1.0417 Ca2N(mp-2686) + 0.9167 CaN2(mp-1009657) + 0.125 V8N(mp-1188283)',
      'energy': -0.4733156905357133,
@@ -1471,7 +1469,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca2N', 'CaN2', 'V8N'], dtype='<U4')},
     {'index': 'mp-1009657_mp-1188283_mp-45',
-     'n_competing': 13,
+     'n_competing': 1,
      'barrier': 0.14989673027000328,
      'summary': '1.5625 Ca(mp-45) + 1.4375 CaN2(mp-1009657) + 0.125 V8N(mp-1188283)',
      'energy': -0.6986126369642848,
@@ -1479,7 +1477,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca', 'CaN2', 'V8N'], dtype='<U4')},
     {'index': 'mp-1009657_mp-1188283_mp-844',
-     'n_competing': 11,
+     'n_competing': 1,
      'barrier': 0.2339704914750757,
      'summary': '0.7812 Ca3N2(mp-844) + 0.6562 CaN2(mp-1009657) + 0.125 V8N(mp-1188283)',
      'energy': -0.4263516082254458,
@@ -1487,7 +1485,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.3333',
      'precursor_formulas': array(['Ca3N2', 'CaN2', 'V8N'], dtype='<U5')},
     {'index': 'mp-1009657_mp-146_mp-2686',
-     'n_competing': 12,
+     'n_competing': 1,
      'barrier': 0.1666290885704565,
      'summary': '1.0 Ca2N(mp-2686) + 1.0 CaN2(mp-1009657) + 1.0 V(mp-146)',
      'energy': -0.5219188557142851,
@@ -1495,7 +1493,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.3333',
      'precursor_formulas': array(['Ca2N', 'CaN2', 'V'], dtype='<U4')},
     {'index': 'mp-1009657_mp-146_mp-45',
-     'n_competing': 13,
+     'n_competing': 1,
      'barrier': 0.13330559124887414,
      'summary': '1.5 Ca(mp-45) + 1.5 CaN2(mp-1009657) + 1.0 V(mp-146)',
      'energy': -0.7382039242857136,
@@ -1503,7 +1501,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.3333',
      'precursor_formulas': array(['Ca', 'CaN2', 'V'], dtype='<U4')},
     {'index': 'mp-1009657_mp-146_mp-844',
-     'n_competing': 13,
+     'n_competing': 1,
      'barrier': 0.17982457701765836,
      'summary': '0.75 Ca3N2(mp-844) + 0.75 CaN2(mp-1009657) + 1.0 V(mp-146)',
      'energy': -0.47683333669642813,
@@ -1511,7 +1509,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.6667',
      'precursor_formulas': array(['Ca3N2', 'CaN2', 'V'], dtype='<U5')},
     {'index': 'mp-1009657_mp-2686_mp-33090',
-     'n_competing': 11,
+     'n_competing': 1,
      'barrier': 0.26490659047170095,
      'summary': '1.1667 Ca2N(mp-2686) + 0.6667 CaN2(mp-1009657) + 0.5 V2N(mp-33090)',
      'energy': -0.33176198761904696,
@@ -1519,7 +1517,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca2N', 'CaN2', 'V2N'], dtype='<U4')},
     {'index': 'mp-1009657_mp-33090_mp-45',
-     'n_competing': 12,
+     'n_competing': 1,
      'barrier': 0.15320162857579173,
      'summary': '1.75 Ca(mp-45) + 1.25 CaN2(mp-1009657) + 0.5 V2N(mp-33090)',
      'energy': -0.584094567619047,
@@ -1527,7 +1525,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca', 'CaN2', 'V2N'], dtype='<U4')},
     {'index': 'mp-1009657_mp-33090_mp-844',
-     'n_competing': 11,
+     'n_competing': 1,
      'barrier': 0.33290455838671207,
      'summary': '0.875 Ca3N2(mp-844) + 0.375 CaN2(mp-1009657) + 0.5 V2N(mp-33090)',
      'energy': -0.2791622154315475,
@@ -1535,7 +1533,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.3333',
      'precursor_formulas': array(['Ca3N2', 'CaN2', 'V2N'], dtype='<U5')},
     {'index': 'mp-1018027_mp-1080711_mp-2686',
-     'n_competing': 4,
+     'n_competing': 1,
      'barrier': 8.259215616280242,
      'summary': '1.5 Ca2N(mp-2686) + 0.25 N2(mp-1080711) + 1.0 VN(mp-1018027)',
      'energy': -0.0904245162846602,
@@ -1543,7 +1541,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca2N', 'N2', 'VN'], dtype='<U4')},
     {'index': 'mp-1018027_mp-1080711_mp-45',
-     'n_competing': 6,
+     'n_competing': 1,
      'barrier': 5.5247031510120665,
      'summary': '3.0 Ca(mp-45) + 1.0 N2(mp-1080711) + 1.0 VN(mp-1018027)',
      'energy': -0.11777613085292815,
@@ -1551,7 +1549,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca', 'N2', 'VN'], dtype='<U2')},
     {'index': 'mp-1018027_mp-2686_mp-676',
-     'n_competing': 11,
+     'n_competing': 1,
      'barrier': 1.306907112973467,
      'summary': '1.4545 Ca2N(mp-2686) + 0.0909 CaN6(mp-676) + 1.0 VN(mp-1018027)',
      'energy': -0.24399278974025917,
@@ -1559,7 +1557,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca2N', 'CaN6', 'VN'], dtype='<U4')},
     {'index': 'mp-1018027_mp-45_mp-676',
-     'n_competing': 14,
+     'n_competing': 1,
      'barrier': 0.3607608414735328,
      'summary': '2.6667 Ca(mp-45) + 0.3333 CaN6(mp-676) + 1.0 VN(mp-1018027)',
      'energy': -0.6778207319047616,
@@ -1567,7 +1565,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca', 'CaN6', 'VN'], dtype='<U4')},
     {'index': 'mp-1018027_mp-844',
-     'n_competing': 2,
+     'n_competing': 0,
      'barrier': 3.272253412857058,
      'summary': '1.0 Ca3N2(mp-844) + 1.0 VN(mp-1018027)',
      'energy': -0.1653833317857143,
@@ -1575,7 +1573,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.5',
      'precursor_formulas': array(['Ca3N2', 'VN'], dtype='<U5')},
     {'index': 'mp-1080711_mp-1188283_mp-2686',
-     'n_competing': 4,
+     'n_competing': 1,
      'barrier': 6.550559067484007,
      'summary': '1.5 Ca2N(mp-2686) + 0.6875 N2(mp-1080711) + 0.125 V8N(mp-1188283)',
      'energy': -0.1018653781756731,
@@ -1583,7 +1581,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca2N', 'N2', 'V8N'], dtype='<U4')},
     {'index': 'mp-1080711_mp-1188283_mp-45',
-     'n_competing': 7,
+     'n_competing': 1,
      'barrier': 43.80863327826171,
      'summary': '3.0 Ca(mp-45) + 1.4375 N2(mp-1080711) + 0.125 V8N(mp-1188283)',
      'energy': -0.12921699274394127,
@@ -1591,7 +1589,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca', 'N2', 'V8N'], dtype='<U3')},
     {'index': 'mp-1080711_mp-1188283_mp-844',
-     'n_competing': 8,
+     'n_competing': 1,
      'barrier': 2.1396301126981703,
      'summary': '1.0 Ca3N2(mp-844) + 0.4375 N2(mp-1080711) + 0.125 V8N(mp-1188283)',
      'energy': -0.1768241936767272,
@@ -1599,7 +1597,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.5',
      'precursor_formulas': array(['Ca3N2', 'N2', 'V8N'], dtype='<U5')},
     {'index': 'mp-1080711_mp-146_mp-2686',
-     'n_competing': 7,
+     'n_competing': 1,
      'barrier': 2.0669988271963304,
      'summary': '1.5 Ca2N(mp-2686) + 0.75 N2(mp-1080711) + 1.0 V(mp-146)',
      'energy': -0.11670033313969586,
@@ -1607,7 +1605,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.5',
      'precursor_formulas': array(['Ca2N', 'N2', 'V'], dtype='<U4')},
     {'index': 'mp-1080711_mp-146_mp-45',
-     'n_competing': 8,
+     'n_competing': 1,
      'barrier': 190.07278908037654,
      'summary': '3.0 Ca(mp-45) + 1.5 N2(mp-1080711) + 1.0 V(mp-146)',
      'energy': -0.1440519477079638,
@@ -1615,7 +1613,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.5',
      'precursor_formulas': array(['Ca', 'N2', 'V'], dtype='<U2')},
     {'index': 'mp-1080711_mp-146_mp-844',
-     'n_competing': 8,
+     'n_competing': 1,
      'barrier': 0.5940953168736282,
      'summary': '1.0 Ca3N2(mp-844) + 0.5 N2(mp-1080711) + 1.0 V(mp-146)',
      'energy': -0.19165914864074973,
@@ -1623,7 +1621,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '1.0',
      'precursor_formulas': array(['Ca3N2', 'N2', 'V'], dtype='<U5')},
     {'index': 'mp-1080711_mp-2686_mp-33090',
-     'n_competing': 4,
+     'n_competing': 1,
      'barrier': 6.897534383668158,
      'summary': '1.5 Ca2N(mp-2686) + 0.5 N2(mp-1080711) + 0.5 V2N(mp-33090)',
      'energy': -0.06161630590265399,
@@ -1631,7 +1629,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca2N', 'N2', 'V2N'], dtype='<U4')},
     {'index': 'mp-1080711_mp-33090_mp-45',
-     'n_competing': 4,
+     'n_competing': 1,
      'barrier': 3.4124722705748,
      'summary': '3.0 Ca(mp-45) + 1.25 N2(mp-1080711) + 0.5 V2N(mp-33090)',
      'energy': -0.08896792047092217,
@@ -1639,7 +1637,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca', 'N2', 'V2N'], dtype='<U3')},
     {'index': 'mp-1080711_mp-33090_mp-844',
-     'n_competing': 6,
+     'n_competing': 1,
      'barrier': 1.0730789337125497,
      'summary': '1.0 Ca3N2(mp-844) + 0.25 N2(mp-1080711) + 0.5 V2N(mp-33090)',
      'energy': -0.1365751214037083,
@@ -1647,7 +1645,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.5',
      'precursor_formulas': array(['Ca3N2', 'N2', 'V2N'], dtype='<U5')},
     {'index': 'mp-1188283_mp-2686_mp-676',
-     'n_competing': 13,
+     'n_competing': 1,
      'barrier': 0.4398321324143746,
      'summary': '1.375 Ca2N(mp-2686) + 0.25 CaN6(mp-676) + 0.125 V8N(mp-1188283)',
      'energy': -0.5241781301785706,
@@ -1655,7 +1653,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca2N', 'CaN6', 'V8N'], dtype='<U4')},
     {'index': 'mp-1188283_mp-45_mp-676',
-     'n_competing': 15,
+     'n_competing': 1,
      'barrier': 2.9662842868538926,
      'summary': '2.5208 Ca(mp-45) + 0.4792 CaN6(mp-676) + 0.125 V8N(mp-1188283)',
      'energy': -0.9342811067559517,
@@ -1663,7 +1661,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca', 'CaN6', 'V8N'], dtype='<U4')},
     {'index': 'mp-1188283_mp-676_mp-844',
-     'n_competing': 12,
+     'n_competing': 1,
      'barrier': 0.4151122626069478,
      'summary': '0.9453 Ca3N2(mp-844) + 0.1641 CaN6(mp-676) + 0.125 V8N(mp-1188283)',
      'energy': -0.44986762695591487,
@@ -1671,7 +1669,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.3333',
      'precursor_formulas': array(['Ca3N2', 'CaN6', 'V8N'], dtype='<U5')},
     {'index': 'mp-146_mp-2686_mp-676',
-     'n_competing': 14,
+     'n_competing': 1,
      'barrier': 0.2762652898621103,
      'summary': '1.3636 Ca2N(mp-2686) + 0.2727 CaN6(mp-676) + 1.0 V(mp-146)',
      'energy': -0.577405153506493,
@@ -1679,7 +1677,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.3333',
      'precursor_formulas': array(['Ca2N', 'CaN6', 'V'], dtype='<U4')},
     {'index': 'mp-146_mp-45_mp-676',
-     'n_competing': 15,
+     'n_competing': 1,
      'barrier': 2.7481665035189966,
      'summary': '2.5 Ca(mp-45) + 0.5 CaN6(mp-676) + 1.0 V(mp-146)',
      'energy': -0.9841188492857138,
@@ -1687,7 +1685,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.3333',
      'precursor_formulas': array(['Ca', 'CaN6', 'V'], dtype='<U4')},
     {'index': 'mp-146_mp-676_mp-844',
-     'n_competing': 14,
+     'n_competing': 1,
      'barrier': 0.17153371719779226,
      'summary': '0.9375 Ca3N2(mp-844) + 0.1875 CaN6(mp-676) + 1.0 V(mp-146)',
      'energy': -0.503708786674107,
@@ -1695,7 +1693,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.6667',
      'precursor_formulas': array(['Ca3N2', 'CaN6', 'V'], dtype='<U5')},
     {'index': 'mp-2686_mp-33090_mp-676',
-     'n_competing': 12,
+     'n_competing': 1,
      'barrier': 0.38699736587413847,
      'summary': '1.4091 Ca2N(mp-2686) + 0.1818 CaN6(mp-676) + 0.5 V2N(mp-33090)',
      'energy': -0.3687528528138523,
@@ -1703,7 +1701,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca2N', 'CaN6', 'V2N'], dtype='<U4')},
     {'index': 'mp-33090_mp-45_mp-676',
-     'n_competing': 14,
+     'n_competing': 1,
      'barrier': 0.2408438056502627,
      'summary': '2.5833 Ca(mp-45) + 0.4167 CaN6(mp-676) + 0.5 V2N(mp-33090)',
      'energy': -0.7890236717857139,
@@ -1711,7 +1709,7 @@ EXPECTED_PLOT_DATA = [
      'exp_precursors': '0.0',
      'precursor_formulas': array(['Ca', 'CaN6', 'V2N'], dtype='<U4')},
     {'index': 'mp-33090_mp-676_mp-844',
-     'n_competing': 12,
+     'n_competing': 1,
      'barrier': 0.31200338455432075,
      'summary': '0.9688 Ca3N2(mp-844) + 0.0937 CaN6(mp-676) + 0.5 V2N(mp-33090)',
      'energy': -0.29259994042038684,
@@ -1721,14 +1719,7 @@ EXPECTED_PLOT_DATA = [
 ]
 
 
-@patch('piro.utils.deepcopy')
-@patch(f'{Reaction.__module__}.deepcopy')
-def test_get_reactions(rdeepcopy_mock, deepcopy_mock):
-    # don't know why, but deepcopy throws errors during this test
-    # maybe the preset PRECURSOR_LIBRARY data for this test is missing something.
-    # note: the below workaround is as slow or slower than deepcopy, so don't replace the real code with it
-    rdeepcopy_mock.side_effect = lambda entries: [ComputedStructureEntry.from_dict(e.as_dict()) for e in entries]
-    deepcopy_mock.side_effect = lambda entries: [ComputedStructureEntry.from_dict(e.as_dict()) for e in entries]
+def test_get_reactions():
 
     # mimics the jupyter notebook
     router = SynthesisRoutes(
@@ -1758,13 +1749,17 @@ def test_get_reactions(rdeepcopy_mock, deepcopy_mock):
     reactions_coeffs_only = {k: {'coeffs': [round(c, 10) for c in v['coeffs']]} for k, v in router.reactions.items()}
     assert reactions_coeffs_only == EXPECTED_REACTIONS
 
-    # check the plot data is expected
-    ignore_columns = [
-        'n_competing',  # n_competing is different because I passed in a small subset of entries to SynthesisRoutes
-        'summary',  # a single number has a rounding error on Mac only. but coeffs are already checked above
-    ]
+    # check that the plot data is as expected
+    our_df = router.plot_data.sort_index().reset_index()
+    expected_df = pd.DataFrame.from_records(EXPECTED_PLOT_DATA)
+
+    # this one has a mac only rounding error
+    ignore_index = expected_df[
+        expected_df['summary'] == '0.7812 Ca3N2(mp-844) + 0.6562 CaN2(mp-1009657) + 0.125 V8N(mp-1188283)'
+    ].index
+
     assert_frame_equal(
-        router.plot_data.sort_index().reset_index().drop(columns=ignore_columns),
-        pd.DataFrame.from_records(EXPECTED_PLOT_DATA).drop(columns=ignore_columns)
+        our_df.drop(ignore_index),
+        expected_df.drop(ignore_index)
     )
 

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -1762,4 +1762,3 @@ def test_get_reactions():
         our_df.drop(ignore_index),
         expected_df.drop(ignore_index)
     )
-


### PR DESCRIPTION
More optimizations around get_reactions and related functions.
RuSr2GdCu2O8-Example runs < 45sec for me

General improvements
- remove need to call deepcopy()
- remove repeated calculations outside of for loops
- better cache method using ComputedStructureEntry.data dictionary instead of lru_cache
- more structural re-architecture within reactions.py
- updated end-to-end test to be more stable