### PR TITLE
Add a toggle to switch api from task to normal

### DIFF
--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -58,6 +58,11 @@
             "prettier --write"
         ]
     },
+    "eslintConfig": {
+        "extends": [
+            "react-app"
+        ]
+    },
     "devDependencies": {
         "@types/react-plotly.js": "^2.5.0",
         "@types/react-router-dom": "^5.1.7",

--- a/web/frontend/src/components/Footer.tsx
+++ b/web/frontend/src/components/Footer.tsx
@@ -8,7 +8,7 @@ export default function Footer() {
         <footer className={styles.Footer}>
             <p>© Copyright Toyota Research Institute {year}</p>
             <p><Link to="/about">About</Link></p>
-            <p><a href="https://www.tri.global/privacy-policy/" target="_blank">Privacy Policy</a></p>
+            <p><a href="https://www.tri.global/privacy-policy/" target="_blank" rel="noreferrer">Privacy Policy</a></p>
         </footer>
     );
 }

--- a/web/frontend/src/pages/Home/AdvancedOptions.tsx
+++ b/web/frontend/src/pages/Home/AdvancedOptions.tsx
@@ -1,5 +1,5 @@
 import { Control, UseFormRegister } from 'react-hook-form';
-import { Collapsible, Input } from '@toyota-research-institute/lakefront';
+import { Collapsible, Input, Toggle } from '@toyota-research-institute/lakefront';
 import styled from '@emotion/styled'
 import styles from './Home.module.css';
 import FormCheckbox from './Checkbox';
@@ -7,6 +7,7 @@ import { Inputs } from './TypeProps';
 import MultiSelect from './MultiSelect';
 import MoreInfo from './MoreInfo';
 import { description } from './description';
+import { useApiMode } from './apiModeContext';
 
 interface Props {
     control: Control<Inputs>;
@@ -20,8 +21,14 @@ const StyledCollapsible = styled(Collapsible)`
   }
 `;
 
+const toggleOptions = [
+    { label: 'Task Route', value: 'task' },
+    { label: 'Normal Route', value: 'normal' }
+]
+
 export default function AdvancedOptions(props: Props) {
     const { control, register, setExcludeCompositions } = props;
+    const { apiMode, setApiMode } = useApiMode();
 
     return (
         <StyledCollapsible
@@ -29,6 +36,7 @@ export default function AdvancedOptions(props: Props) {
         >
             <div className={styles.FormGrid}>
                 <div>
+                    <Toggle options={toggleOptions} onChange={setApiMode} value={apiMode} />
                     <MoreInfo info={description.simple_precursors}>
                         <Input
                             type="number"

--- a/web/frontend/src/pages/Home/Form.tsx
+++ b/web/frontend/src/pages/Home/Form.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
-import { UseMutationResult } from "react-query";
 import { Button, Input } from '@toyota-research-institute/lakefront';
 import ReactTooltip from 'react-tooltip';
 
@@ -14,6 +13,7 @@ import Pressure from './Pressure';
 import MoreInfo from './MoreInfo'
 import { description } from './description';
 import SingleSelect from "./SingleSelect";
+import { useApiMode } from "./apiModeContext";
 
 const addElementOptions = [
     { value: '', label: 'None' },
@@ -21,12 +21,8 @@ const addElementOptions = [
     { value: 'O', label: 'O' }
 ];
 
-interface Props {
-    mutation: UseMutationResult<any, unknown, void, unknown>;
-}
-
-export default function Form(props: Props) {
-    const { mutation } = props;
+export default function Form() {
+    const { mutation } = useApiMode();
     const [pressure, setPressure] = useState<any>(null);
     const [addElements, setAddElements] = useState<{ label: string; value: string; }>();
     const [explicitIncludes, setExplicitIncludes] = useState<{ label: string; value: string; }[]>([]);

--- a/web/frontend/src/pages/Home/Home.tsx
+++ b/web/frontend/src/pages/Home/Home.tsx
@@ -1,15 +1,13 @@
 import Form from './Form';
 import SynthesisPlot from "./SynthesisPlot";
-import { useSubmitTask } from "./usePlotData";
+import { ApiModeProvider } from './apiModeContext';
 
 function Home() {
-    const mutation = useSubmitTask();
-
     return (
-        <>
-            <Form mutation={mutation} />
-            <SynthesisPlot mutation={mutation} />
-        </>
+        <ApiModeProvider>
+            <Form />
+            <SynthesisPlot />
+        </ApiModeProvider>
     );
 }
 

--- a/web/frontend/src/pages/Home/PlotResults.tsx
+++ b/web/frontend/src/pages/Home/PlotResults.tsx
@@ -1,60 +1,16 @@
 import Plot from 'react-plotly.js';
-import { Loading } from '@toyota-research-institute/lakefront';
-import { usePlotData } from "./usePlotData";
 import styles from './Home.module.css';
-import ErrorMessage from "./ErrorMessage";
 
 interface Props {
-    taskId: string;
+    result: any;
 }
 
 function PlotResults(props: Props) {
-    const { taskId } = props;
-    const { data, error, isLoading } = usePlotData(taskId);
-
-    if (isLoading) return (
-        <div className={styles.Loading}>
-            <Loading
-                animated
-                height={24}
-                label="Loading..."
-                width={24}
-            />
-        </div>
-    );
-
-    if (error) {
-        return <ErrorMessage error="Error encountered" />;
-    }
-
-    if (!data) {
-        return null;
-    }
-
-    if (data.status == "started" || data.status == "pending") {
-        return (
-            <div className={styles.Loading}>
-                <Loading
-                    animated
-                    height={24}
-                    label="Request initiated. Loading Results..."
-                    width={24}
-                />
-            </div>
-        );
-    }
-
-    if (data.status == "failure") {
-        return <ErrorMessage error={data.error_message}/>;
-    }
-
-    if (data.status == "invalid") {
-        return <ErrorMessage error="Invalid request sent." />;
-    }
+    const { result } = props;
 
     return (
         <div className={styles.Plot}>
-            <Plot {...data.result} />
+            <Plot {...result} />
         </div>
     );
 }

--- a/web/frontend/src/pages/Home/Pressure.tsx
+++ b/web/frontend/src/pages/Home/Pressure.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useMemo, memo } from "react";
 import { useForm } from 'react-hook-form';
 import { Input } from '@toyota-research-institute/lakefront';
-import Select from 'react-select';
 import MoreInfo from './MoreInfo';
 import { description } from './description';
 import styles from './Home.module.css';

--- a/web/frontend/src/pages/Home/SynthesisPlot.tsx
+++ b/web/frontend/src/pages/Home/SynthesisPlot.tsx
@@ -1,15 +1,12 @@
-import { UseMutationResult } from "react-query";
 import { Loading } from '@toyota-research-institute/lakefront';
 import styles from './Home.module.css';
 import ErrorMessage from "./ErrorMessage";
 import PlotResults from './PlotResults';
+import { useApiMode } from "./apiModeContext";
+import TaskPlot from "./TaskPlot";
 
-interface Props {
-    mutation: UseMutationResult<any, unknown, void, unknown>;
-}
-
-function SynthesisPlot(props: Props) {
-    const { mutation } = props;
+function SynthesisPlot() {
+    const { mutation, apiMode } = useApiMode();
     const { data, error, isLoading } = mutation;
 
     if (isLoading) return (
@@ -37,11 +34,17 @@ function SynthesisPlot(props: Props) {
 
     if (data.error_message) {
         return <ErrorMessage error={data.error_message} />;
-    }    
-    
+    }
+
+    if (apiMode === 'task') {
+        return (
+            <TaskPlot key={data.task_id} taskId={data.task_id} />
+        );
+    }
+
     return (
-        <PlotResults key={data.task_id} taskId={data.task_id} />
-    );    
+        <PlotResults result={data} />
+    );
 }
 
 export default SynthesisPlot;

--- a/web/frontend/src/pages/Home/TaskPlot.tsx
+++ b/web/frontend/src/pages/Home/TaskPlot.tsx
@@ -1,0 +1,58 @@
+import { Loading } from '@toyota-research-institute/lakefront';
+import { useTaskPlotData } from "./usePlotData";
+import styles from './Home.module.css';
+import ErrorMessage from './ErrorMessage';
+import PlotResults from './PlotResults';
+
+interface Props {
+    taskId: string;
+}
+
+function TaskPlot(props: Props) {
+    const { taskId } = props;
+    const { data, error, isLoading } = useTaskPlotData(taskId);
+
+    if (isLoading) return (
+        <div className={styles.Loading}>
+            <Loading
+                animated
+                height={24}
+                label="Loading..."
+                width={24}
+            />
+        </div>
+    );
+
+    if (error) {
+        return <ErrorMessage error="Error encountered" />;
+    }
+
+    if (!data) {
+        return null;
+    }
+
+    if (data.status === "started" || data.status === "pending") {
+        return (
+            <div className={styles.Loading}>
+                <Loading
+                    animated
+                    height={24}
+                    label="Request initiated. Loading Results..."
+                    width={24}
+                />
+            </div>
+        );
+    }
+
+    if (data.status === "failure") {
+        return <ErrorMessage error={data.error_message}/>;
+    }
+
+    if (data.status === "invalid") {
+        return <ErrorMessage error="Invalid request sent." />;
+    }
+
+    return <PlotResults result={data.result} />;
+}
+
+export default TaskPlot;

--- a/web/frontend/src/pages/Home/apiModeContext.tsx
+++ b/web/frontend/src/pages/Home/apiModeContext.tsx
@@ -1,0 +1,34 @@
+import React, { FC, createContext, useContext, useState, useMemo } from 'react';
+import { useSubmitTask, useNormalPlotData } from './usePlotData';
+import { UseMutationResult } from 'react-query';
+
+type ContextProps = {
+    apiMode: string;
+    setApiMode: (v: string) => void;
+    mutation: UseMutationResult<any, unknown, void, unknown>;
+};
+
+const ApiModeContext = createContext({} as ContextProps);
+
+const ApiModeProvider: FC = ({ children }) => {
+    const [apiMode, setApiMode] = useState('task');
+    const taskMutation = useSubmitTask();
+    const normalMutation = useNormalPlotData();
+
+    const value = useMemo(() => ({
+        apiMode,
+        setApiMode,
+        mutation: apiMode === 'task' ? taskMutation : normalMutation
+    }), [apiMode, taskMutation, normalMutation]);
+    return <ApiModeContext.Provider value={value}>{children}</ApiModeContext.Provider>;
+};
+
+function useApiMode() {
+    const context = useContext(ApiModeContext);
+    if (context === undefined) {
+        throw new Error('useApiModeContext must be used within a ApiModeProvider');
+    }
+    return context;
+}
+
+export { ApiModeProvider, useApiMode };

--- a/web/frontend/src/pages/Home/usePlotData.tsx
+++ b/web/frontend/src/pages/Home/usePlotData.tsx
@@ -12,7 +12,19 @@ export const useSubmitTask = () => {
     }));
 }
 
-export const usePlotData = (taskId: string) => {
+export const useNormalPlotData = () => {
+    return useMutation('submitRoute', (newRequest) => fetch('/api/recommend_routes', {
+        method: 'post',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(newRequest)
+    }).then(function(response) {
+        return response.json();
+    }));
+}
+
+export const useTaskPlotData = (taskId: string) => {
     return useQuery(
         ["getPlotData", taskId],
         async () => {


### PR DESCRIPTION
update on the frontend with a toggle to use the synchronous recommend routes api call instead of the celery asynchronous one. Helps with debugging if you don't want the full setup. Leaves open the option open for if the calculations are indeed fast enough, we can deploy without background tasks.