### PR TITLE
relative imports

### DIFF
--- a/web/backend/README.md
+++ b/web/backend/README.md
@@ -79,7 +79,7 @@ pip install -e .
 # set environment variables if not already done previously 
 # export MAPI_KEY={key}
 
-PYTHONPATH=web/backend python web/backend/app/main.py
+python -m web.backend.app.main
 ```
 
 ### Run the celery worker
@@ -91,12 +91,12 @@ docker run -d -p 6379:6379 redis
 
 #### Run the worker
 ```
-PYTHONPATH=web/backend celery -A app.tasks --broker=redis://localhost:6379/0 --result-backend=redis://localhost:6379/0 worker -l info -c 4 -Ofair --without-gossip --without-mingle
+celery -A web.backend.app.tasks --broker=redis://localhost:6379/0 --result-backend=redis://localhost:6379/0 worker -l info -c 4 -Ofair --without-gossip --without-mingle
 ```
 
 #### (optional) Run flower celery monitoring
 ```
-PYTHONPATH=web/backend celery -A app.tasks --broker=redis://localhost:6379/0 --result-backend=redis://localhost:6379/0 flower 
+celery -A web.backend.app.tasks --broker=redis://localhost:6379/0 --result-backend=redis://localhost:6379/0 flower 
 ```
 
 ### Use the web app

--- a/web/backend/app/api.py
+++ b/web/backend/app/api.py
@@ -1,8 +1,8 @@
 import fastapi
 
-from app.models import RecommendRoutesRequest, PlotlyFigureResponse, RecommendRoutesTask
-from app.services import recommend_routes_service
-from app.tasks import recommend_routes_task_start, recommend_routes_task_result
+from .models import RecommendRoutesRequest, PlotlyFigureResponse, RecommendRoutesTask
+from .services import recommend_routes_service
+from .tasks import recommend_routes_task_start, recommend_routes_task_result
 
 router = fastapi.APIRouter()
 

--- a/web/backend/app/index.py
+++ b/web/backend/app/index.py
@@ -3,7 +3,7 @@ import os
 import fastapi
 from starlette.staticfiles import StaticFiles
 
-from app.settings import Settings
+from .settings import Settings
 
 
 def configure_index(app: fastapi.FastAPI):

--- a/web/backend/app/main.py
+++ b/web/backend/app/main.py
@@ -1,9 +1,9 @@
 import uvicorn
 import fastapi
 
-from app import api
-from app.settings import Settings
-from app.index import configure_index
+from . import api
+from .settings import Settings
+from .index import configure_index
 
 app = fastapi.FastAPI(docs_url="/api/docs", openapi_url="/api")
 app.include_router(api.router)

--- a/web/backend/app/services.py
+++ b/web/backend/app/services.py
@@ -1,5 +1,5 @@
 from piro.route import SynthesisRoutes
-from app.models import RecommendRoutesRequest
+from .models import RecommendRoutesRequest
 import inspect
 
 

--- a/web/backend/app/tasks.py
+++ b/web/backend/app/tasks.py
@@ -2,8 +2,8 @@ import json
 import os
 from celery import Celery
 
-from app.models import RecommendRoutesRequest, RecommendRoutesTask, RecommendRoutesTaskStatus
-from app.services import recommend_routes_service
+from .models import RecommendRoutesRequest, RecommendRoutesTask, RecommendRoutesTaskStatus
+from .services import recommend_routes_service
 
 app = Celery(__name__)
 app.conf.update(


### PR DESCRIPTION
align more with running like "python -m app" style, which is more aligned with fastapi recommendations and also celery and uvicorn/gunicorn usage