### PR TITLE
Pareto plotting

### DIFF
--- a/piro/route.py
+++ b/piro/route.py
@@ -419,7 +419,8 @@ class SynthesisRoutes:
                 go.Scatter(
                     x=_x,
                     y=_y,
-                    line=dict(color="firebrick", width=2)
+                    line=dict(color="firebrick", width=2),
+                    hoverinfo='skip'
                 )
             )
             fig.add_trace(
@@ -428,6 +429,7 @@ class SynthesisRoutes:
                     y=[_y[0], self.topsis()["barrier"].max(), None, _y[-1], _y[-1]],
                     line=dict(color="firebrick", width=2, dash="dash"),
                     connectgaps=False,
+                    hoverinfo='skip'
                 )
             )
 


### PR DESCRIPTION
Had a request to modify the pareto plotting so that they don't overlay the hoverinfo, quick fix is to skip the hoverinfo in the Plotly plot so this PR does that.