### PR TITLE
Add validation to cif file uploads

### DIFF
--- a/web/frontend/src/pages/Home/Form.tsx
+++ b/web/frontend/src/pages/Home/Form.tsx
@@ -55,12 +55,15 @@ export default function Form() {
         data.pressure = pressure;
 
         if (compoundMode === 'cif') {
+            data.target_entry_id = null;
             if (cifString) {
                 data.custom_entry_cif_string = cifString;
             } else {
                 // prevent submission, cif string is required
                 return;
             }
+        } else {
+            data.custom_entry_cif_string = null;
         }
 
         // @ts-ignore
@@ -81,7 +84,9 @@ export default function Form() {
                 }
             }
     
-            fileReader.readAsText(file);    
+            if (typeof(file)) {
+                fileReader.readAsText(file);    
+            }
         } 
     }
 
@@ -108,6 +113,7 @@ export default function Form() {
                                     label="cif File"
                                     type="file"
                                     accept=".cif"
+                                    name="cifFile"
                                     required={true}
                                     onChange={handleCIFLoad}
                                     className={styles.FileUpload}

--- a/web/frontend/src/pages/Home/TypeProps.tsx
+++ b/web/frontend/src/pages/Home/TypeProps.tsx
@@ -1,6 +1,6 @@
 export interface Inputs {
-    target_entry_id: string;
-    custom_entry_cif_string: string;
+    target_entry_id: string | null;
+    custom_entry_cif_string: string | null;
     custom_entry_formation_energy_per_atom: number;
     confine_to_icsd: boolean;
     confine_to_stables: boolean;


### PR DESCRIPTION
Add checks to just either submit target compound or cif file upload and not both based on toggle selected.
Also added fix when no file is selected when selecting cif file upload.